### PR TITLE
Feature/render changes

### DIFF
--- a/_layouts/compare.html
+++ b/_layouts/compare.html
@@ -20,11 +20,7 @@
         </div>
       </div>
 
-      {{ content }}
-
-      <div id="content">
-        <div class="js--compare-container"></div>
-      </div>
+      <div id="content"></div>
 
       <div class="l-highlight distribuidorDestacado-About02">
         <div class="wrap">

--- a/_layouts/countries.html
+++ b/_layouts/countries.html
@@ -25,11 +25,7 @@
         </div>
       </div>
 
-      {{ content }}
-
-      <div id="content">
-        <div class="js--country-container"></div>
-      </div>
+      <div id="content"></div>
 
       {% include modules/compare_module.html %}
 

--- a/_layouts/map.html
+++ b/_layouts/map.html
@@ -8,7 +8,7 @@
       {% include header.html %}
 
       <div id="content">
-        <div class="l-map js--map-container"></div>
+        <div id="js--map-container" class="l-map"></div>
       </div>
 
     </div>

--- a/_sass/_print.scss
+++ b/_sass/_print.scss
@@ -32,7 +32,7 @@
 
   //COUNTRY PAGE
 
-  .js--compare-container .js--compare-selectors {
+  .compare-container .js--compare-selectors {
 
     &.is-mobile-hidden {
       display: block !important;

--- a/_sass/layout/_l-main-container.scss
+++ b/_sass/layout/_l-main-container.scss
@@ -17,7 +17,7 @@ $header-height: rem(70px);
 .l-main-container {
   @extend %l-main-container;
   margin-top: $header-height;
-  
+
   @media screen and (min-width: $screen-m) {
     margin-top: 0;
   }
@@ -25,7 +25,7 @@ $header-height: rem(70px);
 
 
 .js--countries,
-.js--compare-container {
+.compare-container {
   min-height: rem(500px);
 }
 

--- a/js/src/lib/view_manager.js
+++ b/js/src/lib/view_manager.js
@@ -1,18 +1,16 @@
-var _ = require('lodash'),
-    Backbone = require('backbone');
+var Backbone = require('backbone');
 
 var ViewManager = Backbone.Model.extend({
+
   defaults: {
     views: {}
   },
 
   el: '#content',
 
-  initialize: function() {},
-
   addView: function(viewName, view) {
     var views = this.get('views');
-    views[viewName] = view;
+    views[viewName] = new view();
 
     this.set('views', views);
   },
@@ -22,21 +20,25 @@ var ViewManager = Backbone.Model.extend({
   },
 
   showView: function(viewName) {
-    var view = this.get('views')[viewName];
-    // this.$el = $(el);
-    debugger
-    if (view !== undefined) {
-      this.set('currentView', view);
+    var view = this.getView(viewName);
 
-      view.show();
-      $(this.el).html(view.el);
-      view.delegateEvents();
+    if (!view) {
+      return;
     }
+
+    this._renderView(view);
   },
 
   hasView: function(viewName) {
-    return (this.get('views')[viewName] !== undefined);
+    return this.get('views')[viewName] ? true : false;
+  },
+
+  _renderView: function(view) {
+    $(this.el).html(view.render().el);
+
+    view.delegateEvents();
   }
+
 });
 
 

--- a/js/src/main.js
+++ b/js/src/main.js
@@ -1,11 +1,8 @@
-var Backbone = require('backbone'),
-    $ = require('jquery');
+var Backbone = require('backbone');
 
 var helpers = require('./helpers/handlebars.js');
 
 var Router = require('./router.js'),
-    router = new Router({
-      $el: $('.l-main-container')
-    });
+    router = new Router();
 
 Backbone.history.start({pushState: true});

--- a/js/src/views/compare/compare.js
+++ b/js/src/views/compare/compare.js
@@ -39,7 +39,8 @@ var status = new (Backbone.Model.extend({
 
 var CompareView = Backbone.View.extend({
 
-  el: '.js--compare-container',
+  is: 'js--compare-container',
+  className: 'compare-container',
 
   events: {
     'click .btn-info' : 'showModalWindow',
@@ -47,6 +48,8 @@ var CompareView = Backbone.View.extend({
   },
 
   initialize: function(options) {
+    this.render();
+
     this.options = options;
     this._setView();
 
@@ -62,32 +65,32 @@ var CompareView = Backbone.View.extend({
     this.indicatorsNamesCollection = new IndicatorsNamesCollection()
 
 
-    if (this.mobile) {
-
-      this.slides = [
-        new MobileSelectorView(),
-        new MobileSelectorView(),
-        new MobileSelectorView()
-      ];
-
-      var promises = this.slides.map(function(slide) {
-        return slide.getPromise();
-      });
-
-      $.when.apply($, promises).done(function() {
-        this._setListeners();
-        if (options) {
-          this.setParams(options);
-        }
-
-      }.bind(this));
-
-    } else {
-
-      this.selectorsView = new CompareSelectorsView();
-      this._setListeners();
-      this.setParams(options);
-    }
+    // if (this.mobile) {
+    //
+    //   this.slides = [
+    //     new MobileSelectorView(),
+    //     new MobileSelectorView(),
+    //     new MobileSelectorView()
+    //   ];
+    //
+    //   var promises = this.slides.map(function(slide) {
+    //     return slide.getPromise();
+    //   });
+    //
+    //   $.when.apply($, promises).done(function() {
+    //     this._setListeners();
+    //     if (options) {
+    //       this.setParams(options);
+    //     }
+    //
+    //   }.bind(this));
+    //
+    // } else {
+    //
+    //   this.selectorsView = new CompareSelectorsView();
+    //   this._setListeners();
+    //   this.setParams(options);
+    // }
   },
 
   _setView: function() {
@@ -134,13 +137,13 @@ var CompareView = Backbone.View.extend({
       this.renderSlides();
       this.calculateLimitPoint();
     } else {
-      this.renderIndicatorNames();
+      // this.renderIndicatorNames();
       this.$el.html(template());
-      this.calculateLimitPoint();
-      this.renderComparesSelector();
+      // this.calculateLimitPoint();
+      // this.renderComparesSelector();
     }
 
-    this.renderLegend();
+    // this.renderLegend();
 
     return this;
   },
@@ -507,14 +510,8 @@ var CompareView = Backbone.View.extend({
   _openShareWindow: function() {
     this.shareWindowView.render();
     this.shareWindowView.delegateEvents();
-  },
-
-  show: function() {
-    this.render();
-  },
-
-  hide: function() {}
-
+  }
+  
 });
 
 module.exports = CompareView;

--- a/js/src/views/compare/compare.js
+++ b/js/src/views/compare/compare.js
@@ -39,7 +39,7 @@ var status = new (Backbone.Model.extend({
 
 var CompareView = Backbone.View.extend({
 
-  is: 'js--compare-container',
+  id: 'js--compare-container',
   className: 'compare-container',
 
   events: {
@@ -511,7 +511,7 @@ var CompareView = Backbone.View.extend({
     this.shareWindowView.render();
     this.shareWindowView.delegateEvents();
   }
-  
+
 });
 
 module.exports = CompareView;

--- a/js/src/views/countries/countries.js
+++ b/js/src/views/countries/countries.js
@@ -14,6 +14,10 @@ var template = Handlebars.compile(
 
 var CountriesView = Backbone.View.extend({
 
+  id: 'js--countries-container',
+
+  // el: '#js--countries-container',
+
   initialize: function() {
     this.countries = new Countries();
 
@@ -53,13 +57,7 @@ var CountriesView = Backbone.View.extend({
     } else {
       new SearchMobileView({ el: $('.js--search') });
     }
-  },
-
-  show: function() {
-    this.render();
-  },
-
-  // hide: function() {}
+  }
 
 });
 

--- a/js/src/views/countries/countries.js
+++ b/js/src/views/countries/countries.js
@@ -16,8 +16,6 @@ var CountriesView = Backbone.View.extend({
 
   id: 'js--countries-container',
 
-  // el: '#js--countries-container',
-
   initialize: function() {
     this.countries = new Countries();
 

--- a/js/src/views/countries/country.js
+++ b/js/src/views/countries/country.js
@@ -60,8 +60,6 @@ var CountryView = Backbone.View.extend({
   render: function() {
     this._hideBanner();
 
-    console.log(this.el);
-
     this.$el.html(template());
     this._renderToolbars();
 

--- a/js/src/views/countries/country.js
+++ b/js/src/views/countries/country.js
@@ -24,7 +24,7 @@ var status = new (Backbone.Model.extend({
 
 var CountryView = Backbone.View.extend({
 
-  el: '.js--country-container',
+  id: 'js--country-container',
 
   events: {
     'click .btn-info': 'showModalWindow',
@@ -38,17 +38,12 @@ var CountryView = Backbone.View.extend({
 
     this.functionHelper = FunctionHelper;
     this.shareWindowView = new ShareWindowView();
-  },
 
-  initializeData: function() {
-    // Initialize collections
     this.country = new Country({id: this.status.get('iso')});
-    this.country.fetch();
-
     this.indicators = new Indicators();
+    // this.country.fetch();
 
-    this.render();
-    this._setListeners();
+    // this._setListeners();
   },
 
   _setListeners: function() {
@@ -62,14 +57,17 @@ var CountryView = Backbone.View.extend({
     this.shareWindowView.delegateEvents();
   },
 
-
   render: function() {
     this._hideBanner();
+
+    console.log(this.el);
 
     this.$el.html(template());
     this._renderToolbars();
 
     this.functionHelper.scrollTop();
+
+    return this;
   },
 
   _renderCountry: function() {
@@ -108,7 +106,6 @@ var CountryView = Backbone.View.extend({
       link.href = '/compare/?isoA=' + iso;
   },
 
-
   _getIndicatorInfo: function(opts) {
     return this.infoWindowModel.getIndicator(opts);
   },
@@ -129,10 +126,6 @@ var CountryView = Backbone.View.extend({
       });
 
     }.bind(this));
-  },
-
-  show: function() {
-    this.initializeData();
   }
 
 });

--- a/js/src/views/map/map.js
+++ b/js/src/views/map/map.js
@@ -5,7 +5,7 @@ var $ = require('jquery'),
 
 var MapView = Backbone.View.extend({
 
-  el: '.js--map-container',
+  el: '#js--map-container',
 
   options: {
     map: {
@@ -41,13 +41,10 @@ var MapView = Backbone.View.extend({
         this.mobile = false;
       },this)
     });
+
   },
 
-  show: function() {
-    this.initViews();
-  },
-
-  initViews: function() {
+  render: function() {
     /* this is the definition for basemap */
     var layer = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
       attribution: '<a href="https://www.mapzen.com/rights">Attribution.</a>. Data &copy;<a href="https://openstreetmap.org/copyright">OSM</a> contributors.'
@@ -56,6 +53,8 @@ var MapView = Backbone.View.extend({
     this.map = L.map(this.el, this.options.map);
     /* ...and we add the basemap layer with Leaflet as well */
     this.map.addLayer(layer);
+
+    return this;
   }
 
 });


### PR DESCRIPTION
Changes:
- Now every view (but map view) renders its own container instead of having it in the layouts.
- Every "js--whatever-stuff" class has been change to id. Because of the id's changes, there are some changes in some SASS files. These changes are only in the view containers, probably we have to change the rest of components by ourselves to try to being consistent.
- Now the ViewManages really manage the views instancing the views and render them itself.
- Removed unnecessary independencies in some views/components.
- Removed _show_ function from views: this function was an unnecessary middleware to initialize the views and its data. It's not necessary anymore.
- Removed the DOM element passed to router, it was pointless.

Take a look and tell me if you find something wrong or something we can improve.

By the way, I have noticed every time we click on a section in the web (map, countries, compare..) it loads everything even when you are in the same section. I don't know if this is something we have to deal because of Jekyll but it's quite strange. Let's have a talk on Monday about this.
